### PR TITLE
Abstract file I/O in SourceManager and implement for GitMgr

### DIFF
--- a/shipyard/git.py
+++ b/shipyard/git.py
@@ -25,6 +25,39 @@ class GitMgr(SourceManager):
             if res.returncode != 0:
                 raise ValueError(res.stderr)
     
+    def read(self, path: str):
+        self.prepare()
+        fpath = os.path.join(self.r.Directory, path)
+        with open(fpath, "rb") as f:
+            data = f.read()
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            return data
+
+    def write(self, path: str, contents) -> None:
+        self.prepare()
+        fpath = os.path.join(self.r.Directory, path)
+        os.makedirs(os.path.dirname(fpath), exist_ok=True)
+        if isinstance(contents, bytes):
+            with open(fpath, "wb") as f:
+                f.write(contents)
+        else:
+            with open(fpath, "w", encoding="utf-8") as f:
+                f.write(contents)
+
+    def list_files(self) -> List[str]:
+        self.prepare()
+        res = subprocess.run(
+            ["git", "ls-files"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cwd=self.r.Directory,
+            encoding="utf-8"
+        )
+        if res.returncode != 0:
+            raise ValueError(res.stderr)
+        return res.stdout.splitlines()
+
     def version(self) -> str:
         """Return the current version"""
         self.prepare()

--- a/shipyard/sources.py
+++ b/shipyard/sources.py
@@ -99,3 +99,15 @@ class SourceManager:
     def reset(self) -> None:
         """Reset the source after changes were made"""
         raise NotImplementedError()
+
+    def read(self, path: str):
+        """Read a file from the source"""
+        raise NotImplementedError()
+
+    def write(self, path: str, contents) -> None:
+        """Write a file to the source"""
+        raise NotImplementedError()
+
+    def list_files(self) -> List[str]:
+        """List all files in the source"""
+        raise NotImplementedError()


### PR DESCRIPTION
This change abstracts file I/O operations into the `SourceManager` base class and provides a concrete implementation for `GitMgr`. This is a first step towards allowing source managers to handle file operations independently of the filesystem.

Key changes:
- `SourceManager.read(path)`: Reads a file from the source.
- `SourceManager.write(path, contents)`: Writes a file to the source, creating directories as needed.
- `SourceManager.list_files()`: Lists all files in the source, honoring ignore rules.
- `GitMgr` implementation of these methods using local filesystem and Git commands.

---
*PR created automatically by Jules for task [4118135875757385675](https://jules.google.com/task/4118135875757385675) started by @nullmonk*