### PR TITLE
Update Dagger engine to use shipyard export

### DIFF
--- a/shipyard/cli.py
+++ b/shipyard/cli.py
@@ -156,7 +156,7 @@ class ShipyardCLI:
         if version:
             p.source.checkout(Version(version))
 
-    def build(self, image=None, package=None, version="", patch=None, interactive=False, artifacts=None, output=None, i=False, p=None):
+    def build(self, image=None, package=None, version="", patch=None, interactive=False, artifacts=None, output=None, i=False, p=None, **kwargs):
         """Build a package using Dagger orchestration.
         
         image: The base image to build on (e.g. debian:bookworm, rockylinux:9)
@@ -173,6 +173,8 @@ class ShipyardCLI:
         if p and not patch:
             patch = p
 
+        variables = kwargs
+
         if image is None or image.startswith("-"):
             print("[!] Error: Image name is required and cannot start with a hyphen.", file=sys.stderr)
             print("    Usage: shipyard build <image> [package] [--patch <path>] [--interactive]", file=sys.stderr)
@@ -188,6 +190,7 @@ class ShipyardCLI:
 
         p = None
         patch_content = ""
+        shipfile_path = ""
         
         if patch:
             if os.path.isfile(patch):
@@ -202,9 +205,10 @@ class ShipyardCLI:
                 elif patch.endswith(".py"):
                     # Assume it points to a Shipfile.py
                     directory = os.path.dirname(os.path.abspath(patch))
-                    print(f"[*] Loading Shipfile from {directory}")
+                    shipfile_path = os.path.abspath(patch)
+                    print(f"[*] Loading Shipfile {shipfile_path} from {directory}")
                     try:
-                        p = Patches(directory)
+                        p = Patches(directory, shipfile=shipfile_path)
                     except Exception as e:
                         print(f"[!] Failed to load shipfile {patch}: {e}", file=sys.stderr)
                         exit(1)
@@ -290,8 +294,10 @@ class ShipyardCLI:
             output_dir or "",
             bool(interactive),
             artifacts or "",
-            os.path.abspath(p._dir) if p else ".",
-            resolved_version or ""
+            os.path.abspath(p._dir) if p else "",
+            resolved_version or "",
+            shipfile_path,
+            variables
         )
 
 

--- a/shipyard/engines/dagger.py
+++ b/shipyard/engines/dagger.py
@@ -10,7 +10,7 @@ from shipyard.patches import Patches
 from shipyard.dagger import DaggerMgr
 from shipyard.version import Version
 
-async def build_package(image: str, package: str, patch_content: str, output_dir: str = "builds", interactive: bool = False, artifacts: str = "", shipyard_dir: str = ".", version: str = ""):
+async def build_package(image: str, package: str, patch_content: str, output_dir: str = "builds", interactive: bool = False, artifacts: str = "", shipyard_dir: str = "", version: str = "", shipfile: str = "", variables: dict = {}):
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # Determine driver
         if any(x in image for x in ["debian", "ubuntu", "linuxmint", "kali"]):
@@ -37,35 +37,50 @@ async def build_package(image: str, package: str, patch_content: str, output_dir
             # Set SHIPYARD_SOURCE env in container
             ctr = ctr.with_env_variable("SHIPYARD_SOURCE", source_dir)
 
+            exported_patch = ""
             # Use Patches in a separate thread because it's synchronous but DaggerMgr uses anyio.from_thread.run
-            def _patch_source(shipyard_dir, ctr, version, source_dir):
-                p = Patches(shipyard_dir)
-                p.source = DaggerMgr(ctr, path=source_dir)
+            def _export_patch(shipyard_dir, ctr, version, source_dir, shipfile, variables):
+                if not shipyard_dir:
+                    return ""
+                try:
+                    p = Patches(shipyard_dir, pull=False, shipfile=shipfile)
+                    p.source = DaggerMgr(ctr, path=source_dir)
 
-                # Resolve version if needed
-                resolved_version = version
-                if not resolved_version:
-                    vers = p.source.versions()
-                    if vers:
-                        resolved_version = str(vers[-1])
+                    if variables:
+                        p.infoObject.Variables.update(variables)
 
-                if resolved_version:
-                    print(f"[*] Resolved version to {resolved_version}")
-                    p._checkout(resolved_version)
+                    # Resolve version if needed
+                    resolved_version = version
+                    if not resolved_version:
+                        vers = p.source.versions()
+                        if vers:
+                            resolved_version = str(vers[-1])
 
-                # Apply patches (both file-based and code-based)
-                print(f"[*] Applying patches to {package} source in container...")
-                relevant_patches = p.versions.get(Version(resolved_version), []) if resolved_version else []
-                p.patch(patches=relevant_patches)
-                return p.source.container
+                    if resolved_version:
+                        print(f"[*] Resolved version to {resolved_version}")
 
-            ctr = await anyio.to_thread.run_sync(_patch_source, shipyard_dir, ctr, version, source_dir)
+                    # Apply patches (both file-based and code-based) and export
+                    print(f"[*] Exporting patches for {package} in container...")
+                    patch, _ = p.export(resolved_version)
+                    return patch
+                except Exception as e:
+                    print(f"[!] Error exporting patch from Shipfile: {e}", file=sys.stderr)
+                    raise e
 
-            # If patch_content was provided from CLI (and it's not empty), apply it using the driver
-            # This allows user-provided .patch files to work alongside Shipfile patches
+            exported_patch = await anyio.to_thread.run_sync(_export_patch, shipyard_dir, ctr, version, source_dir, shipfile, variables)
+
+            # Combine patches
+            final_patch = exported_patch
             if patch_content:
-                print(f"[*] Applying custom patch content...")
-                ctr = await driver.apply_patch(ctr, patch_content, package)
+                if final_patch:
+                    final_patch += "\n" + patch_content
+                else:
+                    final_patch = patch_content
+
+            # If we have patch content, apply it using the driver
+            if final_patch:
+                print(f"[*] Applying patches to {package}...")
+                ctr = await driver.apply_patch(ctr, final_patch, package)
 
             ctr_pre_build = ctr
             ctr = driver.build(ctr, package)

--- a/shipyard/patches.py
+++ b/shipyard/patches.py
@@ -24,13 +24,14 @@ from shipyard.code_file import CodeFile
 class Patches:
     """A manager for the patches that loops through a directory to figure out
     each version supported and that patches that we have for each one"""
-    def __init__(self, directory=".", pull=True):
+    def __init__(self, directory=".", pull=True, shipfile=""):
         self._dir = directory
+        self._shipfile = shipfile
         self.patches = {}
         self.code_patches = {} # Patches that are functions and not .patch files
         self.code_res = defaultdict(list) # when a file matches an RE in this array, goto the func it points to
         self.versions = {}
-        self.infoObject: SourceProgram
+        self.infoObject: SourceProgram = None
         self._files = [] # List of all files in the source
         self.load()
 
@@ -62,7 +63,16 @@ class Patches:
     def load(self):
         """Load and parse the shipfile as well as the patches"""
         # Load the object class
-        for f in glob.glob(path.join(self._dir, "*.py")):
+        files = []
+        if self._shipfile:
+            if path.isabs(self._shipfile):
+                files = [self._shipfile]
+            else:
+                files = [path.join(self._dir, self._shipfile)]
+        else:
+            files = glob.glob(path.join(self._dir, "*.py"))
+
+        for f in files:
             obj = _load_object(f)
             if obj is not None:
                 self.infoObject = SourceProgram.from_object(obj)


### PR DESCRIPTION
This change updates the Dagger engine to leverage the `shipyard export` functionality. This ensures that all patches (file-based and code-based) and variable substitutions are unified into a single patch file before being applied by the package driver. It also adds support for loading specific Shipfiles and passing variable overrides from the CLI.

---
*PR created automatically by Jules for task [11936185404580714201](https://jules.google.com/task/11936185404580714201) started by @nullmonk*